### PR TITLE
Modify workflow to adopt PlatformIO firmware CI build

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -95,14 +95,15 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install platformio
 
-          BUILD_DIR="${GITHUB_WORKSPACE}/fw/${{ matrix.type }}/build"
-          pio run -d "fw/${{ matrix.type }}" -e "${{ matrix.env }}" --project-option="build_dir=${BUILD_DIR}"
+          PROJECT_DIR="fw/${{ matrix.type }}"
+          BUILD_DIR="${GITHUB_WORKSPACE}/fw/build"
+          PIO_BUILD_DIR="${PROJECT_DIR}/.pio/build/${{ matrix.env }}"
 
-          HEX_PATH="${BUILD_DIR}/${{ matrix.env }}/firmware.hex"
-          mv "${HEX_PATH}" "${BUILD_DIR}/fw_${{ matrix.type }}_${{ matrix.name }}.${NEXTBUILD}-${BT}.hex"
+          python3 -m platformio run -d "${PROJECT_DIR}" -e "${{ matrix.env }}"
 
-          rm -rf "${GITHUB_WORKSPACE}/fw/build" || true
-          mv "${BUILD_DIR}" "${GITHUB_WORKSPACE}/fw/build"
+          mkdir -p "${BUILD_DIR}"
+          HEX_PATH="${PIO_BUILD_DIR}/firmware.hex"
+          cp "${HEX_PATH}" "${BUILD_DIR}/fw_${{ matrix.type }}_${{ matrix.name }}.${NEXTBUILD}-${BT}.hex"
 
           if [ "${{ matrix.versioned }}" = "true" ]; then
             NEXTBUILD=$(echo "$NEXTBUILD+1" | bc)

--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -3,16 +3,16 @@ name: Build firmware
 on:
   push:
     paths:
-    - 'SW/arduino/src/**'
-    - '.github/workflows/*.yml'
-    - '!SW/arduino/src/**/githash.h'
-    - '!SW/arduino/src/**/nextversion'
+      - 'fw/**'
+      - '.github/workflows/*.yml'
+      - '!fw/**/src/githash.h'
+      - '!fw/**/nextversion'
   pull_request:
     paths:
-    - 'SW/arduino/src/**'
-    - '.github/workflows/*.yml'
-    - '!SW/arduino/src/**/githash.h'
-    - '!SW/arduino/src/**/nextversion'
+      - 'fw/**'
+      - '.github/workflows/*.yml'
+      - '!fw/**/src/githash.h'
+      - '!fw/**/nextversion'
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -27,48 +27,54 @@ jobs:
         include:
           - name: TFUNIPAYLOAD01
             type: TFUNIPAYLOAD
-            fqbn: clock=8MHz_external
-            channels: 0
+            env: TFUNIPAYLOAD01B_uart
+            versioned: "true"
           - name: TFUNIPAYLOAD01
             type: TFUNIPAYLOAD_MINIMAL
-            fqbn: clock=8MHz_external
-            channels: 0
+            env: TFUNIPAYLOAD01B_uart
+            versioned: "true"
+          - name: TFUNIPAYLOAD01
+            type: TFUNIPAYLOAD-hello-world
+            env: TFUNIPAYLOAD01B_uart
+            versioned: "false"
 
     steps:
-        - name: Checkout
-          uses: actions/checkout@v4
-          with:
-            submodules: true
-            token: ${{ secrets.pat }}
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.pat }}
 
-        - name: Update githash.h and compile  
-          run: |
-            set -euo pipefail
+      - name: Update githash.h and compile
+        run: |
+          set -euo pipefail
 
-            BUILD_TYPE="${{ inputs.build_type }}"
-            BT="CIBuild"
-            if [ "$BUILD_TYPE" = "B" ]; then
-              BT="Beta"
-            fi
-            if [ "$BUILD_TYPE" = "R" ]; then
-              BT="Release"
-            fi 
+          BUILD_TYPE="${{ inputs.build_type }}"
+          BT="CIBuild"
+          if [ "$BUILD_TYPE" = "B" ]; then
+            BT="Beta"
+          fi
+          if [ "$BUILD_TYPE" = "R" ]; then
+            BT="Release"
+          fi
 
-            NEXTVERSION_PATH="SW/arduino/src/${{ matrix.type }}/nextversion"
+          NEXTBUILD=0
+          if [ "${{ matrix.versioned }}" = "true" ]; then
+            NEXTVERSION_PATH="fw/${{ matrix.type }}/nextversion"
             if [ -f "$NEXTVERSION_PATH" ]; then
               PREVMAJOR=$(grep '^MAJOR ' "$NEXTVERSION_PATH" | awk '{print $2}')
               PREVMINOR=$(grep '^MINOR ' "$NEXTVERSION_PATH" | awk '{print $2}')
               NEXTRELEASE=$(grep '^RELEASE ' "$NEXTVERSION_PATH" | awk '{print $2}')
               NEXTBUILD=$(grep '^BUILD ' "$NEXTVERSION_PATH" | awk '{print $2}')
             else
-              PREVMAJOR=$(grep '#define MAJOR' "SW/arduino/src/${{ matrix.type }}/${{ matrix.type }}.ino" | head -n 1 | awk '{print $3}')
-              PREVMINOR=$(grep '#define MINOR' "SW/arduino/src/${{ matrix.type }}/${{ matrix.type }}.ino" | head -n 1 | awk '{print $3}')
+              PREVMAJOR=$(grep '^#define MAJOR' "fw/${{ matrix.type }}/src/main.cpp" | head -n 1 | awk '{print $3}')
+              PREVMINOR=$(grep '^#define MINOR' "fw/${{ matrix.type }}/src/main.cpp" | head -n 1 | awk '{print $3}')
               NEXTRELEASE=0
               NEXTBUILD=0
             fi
 
-            CURMAJOR=`cat SW/arduino/src/${{ matrix.type }}/${{ matrix.type }}.ino|grep MAJOR|head -n 1|cut -d ' ' -f 3`
-            CURMINOR=`cat SW/arduino/src/${{ matrix.type }}/${{ matrix.type }}.ino|grep MINOR|head -n 1|cut -d ' ' -f 3`
+            CURMAJOR=$(grep '^#define MAJOR' "fw/${{ matrix.type }}/src/main.cpp" | head -n 1 | awk '{print $3}')
+            CURMINOR=$(grep '^#define MINOR' "fw/${{ matrix.type }}/src/main.cpp" | head -n 1 | awk '{print $3}')
 
             if [ "$CURMAJOR" = "$PREVMAJOR" ] && [ "$CURMINOR" = "$PREVMINOR" ]; then
               echo "Same version"
@@ -83,54 +89,54 @@ jobs:
             echo "#define GHBUILD ${NEXTBUILD}" >> githash.h
             echo "#define GHBUILDTYPE ${BT}" >> githash.h
 
-            mv githash.h SW/arduino/src/${{ matrix.type }}/
+            mv githash.h "fw/${{ matrix.type }}/src/"
+          fi
 
-            EXTRA_FLAGS="-DCHANNELS=${{ matrix.channels }} -I${GITHUB_WORKSPACE}/SW/arduino/src/${{ matrix.type }}"
+          python3 -m pip install --upgrade pip
+          python3 -m pip install platformio
 
-            sudo snap install arduino-cli
-            arduino-cli core update-index --additional-urls https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json,https://mcudude.github.io/MightyCore/package_MCUdude_MightyCore_index.json > /dev/null
-            arduino-cli core install MightyCore:avr --additional-urls https://mcudude.github.io/MiniCore/package_MCUdude_MiniCore_index.json,https://mcudude.github.io/MightyCore/package_MCUdude_MightyCore_index.json > /dev/null
-            
-            PLATFORM=MightyCore:avr
-            BUILD_DIR="${GITHUB_WORKSPACE}/SW/arduino/${{ matrix.type }}/build"
-            arduino-cli compile --verbose --warnings all --fqbn MightyCore:avr:1284:BOD=disabled,LTO=Os,${{ matrix.fqbn }},variant=modelP --build-property compiler.cpp.extra_flags="${EXTRA_FLAGS}" --build-property compiler.c.extra_flags="${EXTRA_FLAGS}" --build-path "${BUILD_DIR}" SW/arduino/src/${{ matrix.type }}
+          BUILD_DIR="${GITHUB_WORKSPACE}/fw/${{ matrix.type }}/build"
+          pio run -d "fw/${{ matrix.type }}" -e "${{ matrix.env }}" --project-option="build_dir=${BUILD_DIR}"
 
-            find "${BUILD_DIR}" -type f -name "*.hex" -exec bash -c 'mv "$1" "$(dirname "$1")/fw_${{ matrix.type }}_${{ matrix.name }}.'"${NEXTBUILD}-${BT}"'$(basename "$1" | sed -e "s/${{ matrix.type }}\.ino//g")"' _ {} \;
+          HEX_PATH="${BUILD_DIR}/${{ matrix.env }}/firmware.hex"
+          mv "${HEX_PATH}" "${BUILD_DIR}/fw_${{ matrix.type }}_${{ matrix.name }}.${NEXTBUILD}-${BT}.hex"
 
-            rm -r "${GITHUB_WORKSPACE}/SW/arduino/build" || true
-            mv "${BUILD_DIR}" "${GITHUB_WORKSPACE}/SW/arduino/build"
+          rm -rf "${GITHUB_WORKSPACE}/fw/build" || true
+          mv "${BUILD_DIR}" "${GITHUB_WORKSPACE}/fw/build"
 
-            NEXTBUILD=`echo $NEXTBUILD"+1"|bc`
+          if [ "${{ matrix.versioned }}" = "true" ]; then
+            NEXTBUILD=$(echo "$NEXTBUILD+1" | bc)
 
             if [ "$BUILD_TYPE" = "R" ]; then
-              NEXTRELEASE=`echo $NEXTRELEASE"+1"|bc`
+              NEXTRELEASE=$(echo "$NEXTRELEASE+1" | bc)
             fi
             echo "#this file is maintained by github actions" > nextversion
-            echo "MAJOR ${CURMAJOR}" >> nextversion 
-            echo "MINOR ${CURMINOR}" >> nextversion 
-            echo "RELEASE ${NEXTRELEASE}" >> nextversion 
-            echo "BUILD ${NEXTBUILD}" >> nextversion 
+            echo "MAJOR ${CURMAJOR}" >> nextversion
+            echo "MINOR ${CURMINOR}" >> nextversion
+            echo "RELEASE ${NEXTRELEASE}" >> nextversion
+            echo "BUILD ${NEXTBUILD}" >> nextversion
 
             echo "// This file is overwritten by github actions, do not update it manually" > githash.h
             echo "String githash = \"${{ github.sha }},User\";" >> githash.h
             echo "#define GHRELEASE ${NEXTRELEASE}" >> githash.h
             echo "#define GHBUILD 0" >> githash.h
             echo "#define GHBUILDTYPE User" >> githash.h
-      
-            mv nextversion SW/arduino/src/${{ matrix.type }}/
-            mv githash.h SW/arduino/src/${{ matrix.type }}/
-            touch root
 
-        - name: Store data
-          uses: actions/upload-artifact@v4
-          with:
-            name: fw_${{ matrix.type }}_${{ matrix.name }}
-            path: |
-              SW/arduino/build/*.hex
-              SW/arduino/src/${{ matrix.type }}/nextversion
-              SW/arduino/src/${{ matrix.type }}/githash.h
-              root
-            retention-days: 1
+            mv nextversion "fw/${{ matrix.type }}/"
+            mv githash.h "fw/${{ matrix.type }}/src/"
+          fi
+          touch root
+
+      - name: Store data
+        uses: actions/upload-artifact@v4
+        with:
+          name: fw_${{ matrix.type }}_${{ matrix.name }}
+          path: |
+            fw/build/*.hex
+            fw/${{ matrix.type }}/nextversion
+            fw/${{ matrix.type }}/src/githash.h
+            root
+          retention-days: 1
 
   commit:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
@@ -143,37 +149,36 @@ jobs:
           token: ${{ secrets.pat }}
 
       - run: |
-          rm SW/arduino/build -r || true
-          mkdir SW/arduino/build
-          mkdir SW/arduino/artifacts
+          rm -rf fw/build || true
+          mkdir -p fw/build
+          mkdir -p fw/artifacts
 
       - name: Download a Build Artifact
         uses: actions/download-artifact@v4
         with:
-          path: 'SW/arduino/artifacts/'
-
+          path: 'fw/artifacts/'
 
       - name: Update git hash
         run: |
-          for d in `ls SW/arduino/artifacts`;
+          for d in `ls fw/artifacts`;
           do
-            cp -R SW/arduino/artifacts/$d/* ./ ||true
+            cp -R fw/artifacts/$d/* ./ ||true
           done
 
-          rm -rf SW/arduino/artifacts
+          rm -rf fw/artifacts
           rm -rf root
-                          
+
           git status
 
       - name: Get last commit message
         id: last-commit-message
         run: |
           echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
-          
+
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: ${{ steps.last-commit-message.outputs.msg }}, extended build
-          file_pattern: 'SW/arduino/build/* SW/arduino/src/TFUNIPAYLOAD/githash.h SW/arduino/src/TFUNIPAYLOAD/nextversion SW/arduino/src/TFUNIPAYLOAD_MINIMAL/githash.h SW/arduino/src/TFUNIPAYLOAD_MINIMAL/nextversion'
+          file_pattern: 'fw/build/* fw/TFUNIPAYLOAD/src/githash.h fw/TFUNIPAYLOAD/nextversion fw/TFUNIPAYLOAD_MINIMAL/src/githash.h fw/TFUNIPAYLOAD_MINIMAL/nextversion'
           #commit_options: '--amend --no-edit'
           #push_options: '--force'
           skip_fetch: true


### PR DESCRIPTION
### Motivation
- Add the small `TFUNIPAYLOAD-hello-world` PlatformIO project to the firmware CI so it is compiled alongside the other firmware targets.  
- Avoid failing the workflow for projects that do not use the existing `MAJOR/MINOR` or `nextversion` metadata by making version/metadata updates conditional.

### Description
- Added `fw/TFUNIPAYLOAD-hello-world` to the build matrix in `.github/workflows/build_fw.yml` and introduced a per-matrix `versioned` flag.  
- Made githash/nextversion extraction and generation conditional on `matrix.versioned` so non-versioned projects are only compiled and do not require `nextversion` or `#define MAJOR/MINOR`.  
- Migrated workflow paths and build commands to the `fw/**` layout and to PlatformIO invocation (`pio run -d "fw/${{ matrix.type }}" -e "${{ matrix.env }}" --project-option="build_dir=${BUILD_DIR}"`).  
- Updated artifact upload/download paths and the auto-commit `file_pattern` to match the new `fw/` layout while preserving the `.hex` collection behavior.

### Testing
- Verified YAML parse using `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/build_fw.yml'); puts 'ok'"` which returned `ok`.  
- Confirmed the new matrix entries and `versioned` flag with `rg -n "TFUNIPAYLOAD-hello-world|versioned" .github/workflows/build_fw.yml` which found the expected lines.  
- Verified the modified workflow content via a local diff inspection (`git diff` / file listing) and confirmed the conditional logic and path updates are present and correctly formatted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699055c35400832288a738a584de49d3)