### PR TITLE
Move build matrix to external config file fw/build_matrix.yaml

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -20,23 +20,25 @@ on:
         required: false
         type: string
 jobs:
+  load-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Load matrix from file
+        id: set-matrix
+        run: |
+          MATRIX=$(python3 -c "import yaml, json; print(json.dumps({'include': yaml.safe_load(open('fw/build_matrix.yaml'))}))")
+          echo "matrix=${MATRIX}" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ubuntu-latest
+    needs: load-matrix
     strategy:
-      matrix:
-        include:
-          - name: TFUNIPAYLOAD01
-            type: TFUNIPAYLOAD
-            env: TFUNIPAYLOAD01B_uart
-            versioned: "true"
-          - name: TFUNIPAYLOAD01
-            type: TFUNIPAYLOAD_MINIMAL
-            env: TFUNIPAYLOAD01B_uart
-            versioned: "true"
-          - name: TFUNIPAYLOAD01
-            type: TFUNIPAYLOAD-hello-world
-            env: TFUNIPAYLOAD01B_uart
-            versioned: "false"
+      matrix: ${{ fromJson(needs.load-matrix.outputs.matrix) }}
 
     steps:
       - name: Checkout

--- a/fw/build_matrix.yaml
+++ b/fw/build_matrix.yaml
@@ -1,0 +1,12 @@
+- name: TFUNIPAYLOAD01
+  type: TFUNIPAYLOAD
+  env: TFUNIPAYLOAD01B_uart
+  versioned: "true"
+- name: TFUNIPAYLOAD01
+  type: TFUNIPAYLOAD_MINIMAL
+  env: TFUNIPAYLOAD01B_uart
+  versioned: "true"
+- name: TFUNIPAYLOAD01
+  type: TFUNIPAYLOAD-hello-world
+  env: TFUNIPAYLOAD01B_uart
+  versioned: "false"


### PR DESCRIPTION
This pull request refactors the build matrix configuration for the GitHub Actions workflow, moving the matrix definition out of the workflow file and into a separate YAML file. This change improves maintainability and scalability by allowing the build matrix to be managed independently.

Build matrix configuration refactor:

* Added a new job `load-matrix` in `.github/workflows/build_fw.yml` to load the build matrix from `fw/build_matrix.yaml` using a Python script, and output it for use in the build job.
* Removed the hardcoded build matrix from the workflow file and replaced it with a reference to the matrix loaded from the YAML file.
* Created `fw/build_matrix.yaml` to store the build matrix definitions externally, making it easier to update and manage.